### PR TITLE
🤖 Exit on error in docker scripts

### DIFF
--- a/bin/run-in-docker.sh
+++ b/bin/run-in-docker.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env sh
+set -e
 
 # Synopsis:
 # Run the test runner on a solution using the test runner Docker image.

--- a/bin/run-tests-in-docker.sh
+++ b/bin/run-tests-in-docker.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env sh
+set -e
 
 # Synopsis:
 # Test the test runner Docker image by running it against a predefined set of


### PR DESCRIPTION
This PR ensures that building the docker image in the `bin/run-in-docker.sh` and `bin/run-tests-in-docker.sh` scripts must be successful before attempting to run the image.
Without this change, errors while building the Dockerfile are silently ignored.
The tests will then run with the latest version of the test runner image in docker hub, leading to a successful build even though the Dockerfile could not be built.