### PR TITLE
[Fix]: Make react exercise compatiable with the test runner

### DIFF
--- a/helpers/scaffold_json.cr
+++ b/helpers/scaffold_json.cr
@@ -83,7 +83,7 @@ class TestVisitor < Crystal::Visitor
   def visit(node)
     true
   end
-  
+
   private def handle_visit_describe_call(node : Crystal::Call)
     case arg = node.args[0]
     when Crystal::StringLiteral

--- a/helpers/scaffold_json.cr
+++ b/helpers/scaffold_json.cr
@@ -83,9 +83,14 @@ class TestVisitor < Crystal::Visitor
   def visit(node)
     true
   end
-
+  
   private def handle_visit_describe_call(node : Crystal::Call)
-    @breadcrumbs << node.args[0].not_nil!.as(Crystal::StringLiteral).value
+    case arg = node.args[0]
+    when Crystal::StringLiteral
+      @breadcrumbs << arg.value
+    when Crystal::Path
+      @breadcrumbs << arg.to_s
+    end
     accept(node.block.not_nil!)
   end
 

--- a/tests/example-success-with-path/.meta/config.json
+++ b/tests/example-success-with-path/.meta/config.json
@@ -1,0 +1,12 @@
+{
+  "files": {
+    "solution": [
+      "src/mini_bob.cr"
+    ],
+    "test": [
+      "spec/mini_bob_spec.cr"
+    ]
+  },
+  "blurb": "Create a sentence of the form \"One for X, one for me.\".",
+  "source_url": "https://github.com/exercism/problem-specifications/issues/757"
+}

--- a/tests/example-success-with-path/expected_results.json
+++ b/tests/example-success-with-path/expected_results.json
@@ -1,0 +1,11 @@
+{
+  "version": 2,
+  "status": "pass",
+  "tests": [
+    {
+      "name": "Bob::Bob1 #hey responds to stating something",
+      "test_code": "Bob::Bob1.hey(\"Tom-ay-to, tom-aaaah-to.\").should eq \"Whatever.\"",
+      "status": "pass"
+    }
+  ]
+}

--- a/tests/example-success-with-path/spec/mini_bob_spec.cr
+++ b/tests/example-success-with-path/spec/mini_bob_spec.cr
@@ -1,0 +1,10 @@
+require "spec"
+require "../src/*"
+
+describe Bob::Bob1 do
+  describe "#hey" do
+    it "responds to stating something" do
+      Bob::Bob1.hey("Tom-ay-to, tom-aaaah-to.").should eq "Whatever."
+    end
+  end
+end

--- a/tests/example-success-with-path/src/mini_bob.cr
+++ b/tests/example-success-with-path/src/mini_bob.cr
@@ -1,0 +1,7 @@
+class Bob
+  class Bob2
+    def self.hey(string : String)
+      "Whatever."
+    end
+  end
+end

--- a/tests/example-success-with-path/src/mini_bob.cr
+++ b/tests/example-success-with-path/src/mini_bob.cr
@@ -1,5 +1,5 @@
 class Bob
-  class Bob2
+  class Bob1
     def self.hey(string : String)
       "Whatever."
     end


### PR DESCRIPTION
This pr fixes so that test that uses a path e.g "class1::class2" syntax works with the test runner, which the react exercise utlize.